### PR TITLE
Let Unicode work, add Travis and Coveralls coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: python
+python:
+  - "2.7"
+  - "3.3"
+  - "3.4"
+  - "3.5"
+  - "3.5-dev" # 3.5 development branch
+  - "nightly" # currently points to 3.6-dev
+script:
+  - "python setup.py test"
+  - coverage run --source=awis setup.py test
+after_success:
+  - coveralls

--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,4 @@
+[![Build Status](https://travis-ci.org/muhuk/python-awis.svg?branch=master)](https://travis-ci.org/muhuk/python-awis)
 Wraps `Alexa Web Information Service`_.
 
 Usage

--- a/awis/__init__.py
+++ b/awis/__init__.py
@@ -121,7 +121,7 @@ class AwisApi(object):
         params = {
             "Action": "CategoryListings",
             "ResponseGroup": "Listings",
-            "Path": quote(path),
+            "Path": path,
             "SortBy": SortBy,
             "Start": str(Start),
             "Recursive": str(not not Recursive),

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+pytest==2.8.5
+coverage==4.0.3
+coveralls==1.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[aliases]
+test=pytest

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from distutils.core import setup
+from setuptools import setup
 from distutils.command.install import INSTALL_SCHEMES
 from awis import __version__, __maintainer__, __email__
 
@@ -14,6 +14,8 @@ long_description = open('README.rst').read()
 
 
 setup(
+    setup_requires=['pytest-runner'],
+    tests_require=['pytest'],
     name = 'python-awis',
     version = __version__,
     url = 'http://github.com/muhuk/python-awis',

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,3 @@
+import sys, os
+sys.path.append(os.path.abspath('.'))
+

--- a/test/test_awis.py
+++ b/test/test_awis.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+from awis import AwisApi
+import os
+
+def test_unicode():
+  api = AwisApi(os.environ['AWS_ACCESS_ID'], os.environ['AWS_SECRET_ACCESS_KEY'])
+  tree = api.category_listings("Top/World/Dansk/Børn_og_unge/Kultur")
+  listings = tree.findall('.//awis:Listing', AwisApi.NS_PREFIXES)
+  
+  assert len(listings) > 0


### PR DESCRIPTION
This is to address #11.  I've added a test and also stuck in TravisCI and Coveralls coverage.
